### PR TITLE
fix: Safely handle missing postedby in startup ratings

### DIFF
--- a/controller/startupCtrl.js
+++ b/controller/startupCtrl.js
@@ -187,7 +187,13 @@ const rating = asyncHandler(async (req, res) => {
   const { _id } = req.user;
   const {  star, prodId, comment } = req.body;
   try {
+    validateMongoDbId(prodId);
     const startup = await Startup.findById(prodId);
+    if (!startup) {
+      res.status(404);
+      throw new Error("Startup not found");
+    }
+
     if (startup.ratings.some((rating) => !rating.postedby)) {
       // handle the case where one of the elements in the startup.ratings array doesn't have a postedBy property
       console.log("Found ratings missing the postedby property. Skipping them.");

--- a/controller/startupCtrl.js
+++ b/controller/startupCtrl.js
@@ -188,13 +188,13 @@ const rating = asyncHandler(async (req, res) => {
   const {  star, prodId, comment } = req.body;
   try {
     const startup = await Startup.findById(prodId);
-    if (startup.ratings.some((rating) => !rating.postedBy)) {
+    if (startup.ratings.some((rating) => !rating.postedby)) {
       // handle the case where one of the elements in the startup.ratings array doesn't have a postedBy property
-      console.log("Something here  rating haven't the postedBy");
+      console.log("Found ratings missing the postedby property. Skipping them.");
     }
 
     let alreadyRated = startup.ratings.find(
-      (userId) => userId.postedby.toString() === _id.toString()
+      (userId) => userId.postedby && userId.postedby.toString() === _id.toString()
     );
     if (alreadyRated) {
       const updateRating = await Startup.updateOne(


### PR DESCRIPTION
This submit resolves an issue in `controller/startupCtrl.js` where the app could crash if a rating in the `startup.ratings` array is missing its `postedby` field.

The changes involve:
1. Fixing the case-sensitive typo `!rating.postedBy` to `!rating.postedby` when logging the anomaly.
2. Updating the `.find` iterator to first check that `userId.postedby` exists before attempting to call `.toString()` on it, allowing us to safely skip broken ratings without throwing runtime errors.

---
*PR created automatically by Jules for task [10324407289460311848](https://jules.google.com/task/10324407289460311848) started by @Ken-Andre*